### PR TITLE
Made crtsh.go behave more like an API and less like a program

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/brennan-macaig/go-crtsh-api
+module github.com/JFryy/go-crtsh-api
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/JFryy/go-crtsh-api
+module github.com/brennan-macaig/go-crtsh-api
 
 go 1.14


### PR DESCRIPTION
I stumbled across this API/wrapper while trying to write an alternative to some bash script that specifies how many certificates are used already via letsencrypt. I like the wrapper, but figured it could use a few changes

- Added serial numbers
- Removed `log.Fatalf` and made the functions return `Type, error` to check for errors in a way that doesn't imply explosion

I'm happy to update README.md as needed to reflect these changes in how the API works.